### PR TITLE
Add the namespace to the commit message

### DIFF
--- a/ausroller.py
+++ b/ausroller.py
@@ -193,7 +193,8 @@ class Ausroller(object):
                 return
 
             repo.commit_files(files_to_commit,
-                              "Created rollout for {} with version {}\n\n{}".format(
+                              "[{}] Created rollout for {} with version {}\n\n{}".format(
+                                  self.namespace,
                                   self.app_name,
                                   self.app_version,
                                   self.commit_message))


### PR DESCRIPTION
* The first line of the commit message "Created rollout for.." has now
  the namespace in square brackets at the beginning.
  Now you can see for what namespace a rollout was commit to your git
  repo.
  Fixes #8