### PR TITLE
Make ausroller pip installable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
   - "2.7"
-install: "pip install -r requirements-dev.txt"
+install: "pip install . -e .[dev]"
 script: nosetests -v --with-coverage --cover-package=ausroller

--- a/ausroller.py
+++ b/ausroller.py
@@ -1,24 +1,5 @@
 #!/usr/bin/env python2
-# encoding: utf-8
+# encoding utf-8
+from ausroller import main
 
-from ausroller import Configuration
-from ausroller import Ausroller
-import logging
-
-
-def main():
-    # parse arguments from command line and
-    # read configuration file
-
-    c = Configuration()
-    c.parse_args()
-    logging.basicConfig(format='%(levelname)s:\t%(message)s',
-                        level=c.log_level)
-    c.read_config()
-
-    a = Ausroller(c)
-    resources = a.prepare_rollout()
-    a.rollout(resources)
-
-if __name__ == '__main__':
-    main()
+main()

--- a/ausroller/__init__.py
+++ b/ausroller/__init__.py
@@ -1,2 +1,3 @@
 from config import Configuration
 from core import Ausroller
+from main import main

--- a/ausroller/main.py
+++ b/ausroller/main.py
@@ -1,0 +1,22 @@
+from ausroller import Configuration
+from ausroller import Ausroller
+
+import logging
+
+
+def main():
+    # parse arguments from command line and
+    # read configuration file
+
+    c = Configuration()
+    c.parse_args()
+    logging.basicConfig(format='%(levelname)s:\t%(message)s',
+                        level=c.log_level)
+    c.read_config()
+
+    a = Ausroller(c)
+    resources = a.prepare_rollout()
+    a.rollout(resources)
+
+if __name__ == '__main__':
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,0 @@
-nose
-nose-cov
--r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-gbp >= 0.8.9
-dateutils
-jinja2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,71 @@
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='ausroller',
+    version='0.2.0-alpha',
+    description='Deploy applications to kubernetes clusters',
+    long_description=long_description,
+
+    url='https://github.com/endocode/ausroller',
+
+    # Author details
+    author='Markus Herpich',
+    author_email='markus@endocode.com',
+
+    # Choose your license
+    license='GPLv3',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: System Administrators',
+        'Topic :: System',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2.7',
+    ],
+
+    keywords='kubernetes k8s microservice deployment',
+
+    packages=find_packages(exclude=['tests']),
+
+    install_requires=['gbp',
+                      'dateutils',
+                      'jinja2'],
+
+    # List additional groups of dependencies here (e.g. development
+    # dependencies). You can install these using the following syntax,
+    # for example:
+    # $ pip install -e .[dev]
+    extras_require={
+        'dev': ['nose', 'nose-cov']
+    },
+
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # pip to create the appropriate form of executable for the target platform.
+    entry_points={
+        'console_scripts': [
+            'ausroller=ausroller.main:main',
+        ],
+    },
+)


### PR DESCRIPTION
This pr uses @hemarkus  work from https://github.com/endocode/ausroller/pull/18 to install ausroller with pip. Also changes the .travis.yml to use pip to install during tests.

This PR sits on top of https://github.com/endocode/ausroller/pull/12. 