### PR TITLE
add kube module to hold kubectl related code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: python
 python:
   - "2.7"
 install: "pip install . -e .[dev]"
-script: nosetests -v --with-coverage --cover-package=ausroller
+script: nosetests -v --with-coverage --cover-package=ausroller --with-doctest

--- a/ausroller/__init__.py
+++ b/ausroller/__init__.py
@@ -1,3 +1,4 @@
 from config import Configuration
 from core import Ausroller
 from main import main
+from kube import KubeCtl

--- a/ausroller/config.py
+++ b/ausroller/config.py
@@ -48,6 +48,7 @@ class Configuration(object):
         self.configfile = args.config
         self.extravarsfile = args.extravars
         self.secretsfile = args.secret
+        self.kubectlpath = None
 
     def read_config(self):
         home_dir = os.path.expanduser("~")

--- a/ausroller/kube.py
+++ b/ausroller/kube.py
@@ -1,0 +1,51 @@
+import logging
+import shlex
+import subprocess
+
+kubectl_format = "{kubectl} --namespace={namespace} {subcommand}"
+kubectl_default_bin = "kubectl"
+
+
+class KubeCtl(object):
+
+    def __init__(self, namespace, path=kubectl_default_bin, dryrun=False):
+        if path is not None:
+            self.path = path
+        else:
+            self.path = kubectl_default_bin
+        self.namespace = namespace
+        self.dryrun = dryrun
+
+    def _run(self, subcmd):
+        '''
+        (str) -> str or None
+        Run the given Str subcmd as sub command of kubectl
+        and return the output as string.
+
+        >>> k = KubeCtl('doctest', path='echo kubectl')
+        >>> k._run('version')
+        'kubectl --namespace=doctest version\\n'
+        >>>
+        '''
+        cmd = shlex.split(kubectl_format.format(
+            kubectl=self.path, namespace=self.namespace, subcommand=subcmd))
+
+        if self.dryrun:
+            logging.debug("Skipping '{}'".format(" ".join(cmd)))
+            return
+        else:
+            logging.debug("Running '{}'".format(" ".join(cmd)))
+
+        try:
+            return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            logging.error("kubectl failed with [{}]".format(e.output))
+            raise
+
+    def apply_resourcefile(self, resourcefile):
+        '''
+        (str)
+        Runs 'kubectl apply -f' with the given resource file.
+        '''
+        subcmd = "apply -f {}".format(resourcefile)
+        self._run(subcmd)

--- a/tests/test_kube.py
+++ b/tests/test_kube.py
@@ -1,0 +1,45 @@
+import unittest
+from ausroller import KubeCtl
+from subprocess import CalledProcessError
+
+
+class KubeCtlTest(unittest.TestCase):
+
+    def test_run_dryrun(self):
+        '''
+        Check that no command is executed when using dryrun.
+        '''
+        l = KubeCtl('unittest', path="/does/not/exist", dryrun=True)
+        retval = l._run('version')
+        self.assertEqual(None, retval)
+
+    def test_run_with_unsuccessful_cmd(self):
+        '''
+        Check that an Exception is raised when the command fails.
+        '''
+        l = KubeCtl('unittest', path='/bin/false', dryrun=False)
+        with self.assertRaises(CalledProcessError):
+            l._run('a')
+
+    def test_apply_resourcefile(self):
+        '''
+        Check that the sub command is proper constructed.
+        We let the command execution fail on purpose to get
+        an exception back from the called method so we can check the
+        complete command.
+        '''
+        t = KubeCtl(namespace='doctest', path='/bin/false')
+        with self.assertRaises(CalledProcessError) as e:
+            t.apply_resourcefile('/path/to/resourcefile')
+        self.assertEqual(e.exception.cmd, ['/bin/false',
+                                           '--namespace=doctest',
+                                           'apply', '-f',
+                                           '/path/to/resourcefile'])
+
+    def test_KubeCtl_defaults(self):
+        '''
+        Check that KubeCtl uses sane defaults.
+        '''
+        k = KubeCtl('unittest', path=None)
+        self.assertEqual('kubectl', k.path)
+        self.assertEqual(False, k.dryrun)


### PR DESCRIPTION
Introduce the kube module to hold the code related to running the
kubectl command. 

Conflicts:
	ausroller.py