### PR TITLE
WIP: Add capability to run plugins between lifecycle steps

### DIFF
--- a/ausroller/config.py
+++ b/ausroller/config.py
@@ -49,6 +49,8 @@ class Configuration(object):
         self.extravarsfile = args.extravars
         self.secretsfile = args.secret
         self.kubectlpath = None
+        self.plugin_path = os.path.join(os.path.expanduser("~"),
+                                        ".ausroller_plugins/")
 
     def read_config(self):
         home_dir = os.path.expanduser("~")

--- a/ausroller/main.py
+++ b/ausroller/main.py
@@ -15,8 +15,7 @@ def main():
     c.read_config()
 
     a = Ausroller(c)
-    resources = a.prepare_rollout()
-    a.rollout(resources)
+    a.deploy()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* We can run plugins between the single steps in the "lifecycle" of the
  rollout:
  - after the templates are rendered
  - after the resource files are written to disk
  - after the resources are rolled out to kubernetes

ToDo: Add documention to README how Python plugins and arbitrary plugins are supposed to work. 