### PR TITLE
Fix versioning

### DIFF
--- a/ausroller/config.py
+++ b/ausroller/config.py
@@ -40,7 +40,7 @@ class Configuration(object):
         args = parser.parse_args()
 
         self.app_name = args.app
-        self.app_version = args.version
+        self.app_version = args.ver
         self.namespace = args.namespace
         self.commit_message = args.message
         self.is_dryrun = args.dryrun


### PR DESCRIPTION
Traceback (most recent call last):
  File "ausroller.py", line 5, in <module>
    main()
  File "/home/julian/dev/endocode/ausroller/ausroller/main.py", line 12, in main
    c.parse_args()
  File "/home/julian/dev/endocode/ausroller/ausroller/config.py", line 43, in parse_args
    self.app_version = args.version
AttributeError: 'Namespace' object has no attribute 'version'