### PR TITLE
Fix dry run mode

### DIFF
--- a/ausroller/kube.py
+++ b/ausroller/kube.py
@@ -33,7 +33,8 @@ class KubeCtl(object):
         self.ctx_pattern = re.compile(
             "^{}$".format(required_ctx), re.MULTILINE)
 
-        if not skip_verify:
+        if not skip_verify and not dryrun:
+            logging.debug("Running verification checks")
             try:
                 self.verify_version()
                 self.verify_context_available()


### PR DESCRIPTION
Skip the verification steps in dryrun mode as those checks will fail
since the dryrun will skip each kubernetes command.